### PR TITLE
Add authenticator for use with Authentication plugin

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,6 +20,7 @@
 ## 必要要件
 
 - CakePHP >= 3.5
+- CakePHP Authentication plugin 1.x
 
 ## インストール
 
@@ -57,17 +58,13 @@ bin/cake migrations migrate -p LoginAttempts
 
 ### 使用方法
 
-`Form` 認証ハンドラーの代わりに `LoginAttempts.Form` を使用してください。
+`Form` 認証機能の代わりに `LoginAttempts.Form` を使用してください。
 
 ```
-        $this->loadComponent('Auth', [
-            'authenticate' => [
-                'LoginAttempts.Form' => [
-                    'fields' => ['username' => 'email'],
-                    'attemptLimit' => 5,
-                    'attemptDuration' => '+5 minutes',
-                ],
-            ],
+        $service->loadAuthenticator('Authentication.Form', [
+            'fields' => ['username' => 'email'],
+            'attemptLimit' => 5,
+            'attemptDuration' => '+5 minutes',
         ]);
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@
 ## 必要要件
 
 - CakePHP >= 3.5
-- CakePHP Authentication plugin 1.x
+- (任意) CakePHP Authentication plugin 1.x
 
 ## インストール
 
@@ -61,7 +61,21 @@ bin/cake migrations migrate -p LoginAttempts
 `Form` 認証機能の代わりに `LoginAttempts.Form` を使用してください。
 
 ```
-        $service->loadAuthenticator('Authentication.Form', [
+        $this->loadComponent('Auth', [
+            'authenticate' => [
+                'LoginAttempts.Form' => [
+                    'fields' => ['username' => 'email'],
+                    'attemptLimit' => 5,
+                    'attemptDuration' => '+5 minutes',
+                ],
+            ],
+        ]);
+```
+
+Authentication プラグインを使う場合:
+
+```
+        $service->loadAuthenticator('LoginAttempts.Form', [
             'fields' => ['username' => 'email'],
             'attemptLimit' => 5,
             'attemptDuration' => '+5 minutes',

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 ## Requirements
 
 - CakePHP >= 3.5
+- CakePHP Authentication plugin 1.x
 
 ## Installation
 
@@ -53,17 +54,13 @@ bin/cake migrations migrate -p LoginAttempts
 
 ### Usage
 
-Use `LoginAttempts.Form` authenticate instead of `Form`.
+Use `LoginAttempts.Form` authenticator instead of `Form`.
 
 ```
-        $this->loadComponent('Auth', [
-            'authenticate' => [
-                'LoginAttempts.Form' => [
-                    'fields' => ['username' => 'email'],
-                    'attemptLimit' => 5,
-                    'attemptDuration' => '+5 minutes',
-                ],
-            ],
+        $service->loadAuthenticator('Authentication.Form', [
+            'fields' => ['username' => 'email'],
+            'attemptLimit' => 5,
+            'attemptDuration' => '+5 minutes',
         ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Requirements
 
 - CakePHP >= 3.5
-- CakePHP Authentication plugin 1.x
+- (Optional) CakePHP Authentication plugin 1.x
 
 ## Installation
 
@@ -57,7 +57,21 @@ bin/cake migrations migrate -p LoginAttempts
 Use `LoginAttempts.Form` authenticator instead of `Form`.
 
 ```
-        $service->loadAuthenticator('Authentication.Form', [
+        $this->loadComponent('Auth', [
+            'authenticate' => [
+                'LoginAttempts.Form' => [
+                    'fields' => ['username' => 'email'],
+                    'attemptLimit' => 5,
+                    'attemptDuration' => '+5 minutes',
+                ],
+            ],
+        ]);
+```
+
+If use are using Authentication plugin:
+
+```
+        $service->loadAuthenticator('LoginAttempts.Form', [
             'fields' => ['username' => 'email'],
             'attemptLimit' => 5,
             'attemptDuration' => '+5 minutes',

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,14 @@
     "license": ["MIT"],
     "require": {
         "php": ">=5.6",
-        "cakephp/cakephp": "~3.5",
-        "cakephp/authentication": "^1.0"
+        "cakephp/cakephp": "~3.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.14|^6.0",
         "cakephp/cakephp-codesniffer": "^3.1"
+    },
+    "suggest": {
+        "cakephp/authentication": "To use FormAuthenticator."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": ["MIT"],
     "require": {
         "php": ">=5.6",
-        "cakephp/cakephp": "~3.5"
+        "cakephp/cakephp": "~3.5",
+        "cakephp/authentication": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.14|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -8,18 +8,18 @@
         "cakephp/cakephp": "~3.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7|^6.0",
+        "phpunit/phpunit": "^5.7.14|^6.0",
         "cakephp/cakephp-codesniffer": "^3.1"
     },
     "autoload": {
         "psr-4": {
-            "LoginAttempts\\": "src"
+            "LoginAttempts\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "LoginAttempts\\Test\\": "tests",
-            "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
+            "LoginAttempts\\Test\\": "tests/",
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
     }
 }

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -24,6 +24,7 @@ class FormAuthenticator extends BaseFormAuthenticate
     public function __construct(ComponentRegistry $registry, array $config = [])
     {
         $this->_defaultConfig += [
+            'userModel' => 'Users',
             'attemptLimit' => 5,
             'attemptDuration' => '+5 minutes',
             'attemptAction' => 'login',

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -4,6 +4,7 @@ namespace LoginAttempts\Authenticator;
 
 use Authentication\Authenticator\FormAuthenticator as BaseFormAuthenticator;
 use Authentication\Authenticator\Result;
+use Authentication\Authenticator\ResultInterface;
 use Authentication\Identifier\IdentifierInterface;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
@@ -60,14 +61,14 @@ class FormAuthenticator extends BaseFormAuthenticator
 
         // check attempts
         if (!$attempts->check($ip, $action, $this->getConfig('attemptLimit'))) {
-            return new Result(null, Result::FAILURE_OTHER);
+            return new Result(null, ResultInterface::FAILURE_OTHER);
         }
 
         $result = parent::authenticate($request, $response);
         if ($result->isValid()) {
             // on success clear attempts
             $attempts->reset($ip, $action);
-        } else {
+        } elseif ($result->getStatus() === ResultInterface::FAILURE_IDENTITY_NOT_FOUND) {
             // on failure record attempts
             $attempts->fail($ip, $action, $this->getConfig('attemptDuration'));
         }

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -6,7 +6,6 @@ use Authentication\Identifier\IdentifierInterface;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\I18n\Time;
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
@@ -25,7 +24,6 @@ class FormAuthenticatorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.LoginAttempts.AuthUsers',
         'plugin.LoginAttempts.Auth\FormAuthenticate\Attempts',
     ];
 
@@ -56,12 +54,6 @@ class FormAuthenticatorTest extends TestCase
     private $Attempts;
 
     /**
-     *
-     * @var Table
-     */
-    private $Users;
-
-    /**
      * Sets up
      */
     public function setUp()
@@ -76,7 +68,6 @@ class FormAuthenticatorTest extends TestCase
         ]);
 
         // set password
-        $this->Users = TableRegistry::get('AuthUsers');
         $this->Attempts = TableRegistry::get('LoginAttempts.Attempts');
 
         $this->response = $this->getMockBuilder(Response::class)->getMock();

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace LoginAttempts\Test\TestCase\Authenticator;
+
+use Cake\Controller\ComponentRegistry;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\I18n\Time;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Security;
+use LoginAttempts\Authenticator\FormAuthenticator;
+use LoginAttempts\Model\Entity\Attempt;
+use LoginAttempts\Model\Table\AttemptsTable;
+
+/**
+ * test for FormAuthenticator
+ */
+class FormAuthenticatorTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.LoginAttempts.AuthUsers',
+        'plugin.LoginAttempts.Auth\FormAuthenticate\Attempts',
+    ];
+
+    /**
+     * @var ComponentRegistry
+     */
+    private $Collection;
+
+    /**
+     * @var FormAuthenticator
+     */
+    private $auth;
+
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * @var string
+     */
+    private $salt;
+
+    /**
+     *
+     * @var AttemptsTable
+     */
+    private $Attempts;
+
+    /**
+     *
+     * @var Table
+     */
+    private $Users;
+
+    /**
+     * Sets up
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->Collection = $this->getMockBuilder(ComponentRegistry::class)->getMock();
+        $this->auth = new FormAuthenticator($this->Collection, [
+            'userModel' => 'AuthUsers',
+        ]);
+
+        // set password
+        $this->Users = TableRegistry::get('AuthUsers');
+        $this->Attempts = TableRegistry::get('LoginAttempts.Attempts');
+
+        $this->response = $this->getMockBuilder(Response::class)->getMock();
+
+        $this->salt = Security::getSalt();
+        Security::setSalt('DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi');
+    }
+
+    /**
+     * Tears down
+     */
+    public function tearDown()
+    {
+        unset($this->auth, $this->Users, $this->Attempts);
+        Security::setSalt($this->salt);
+        Time::setTestNow();
+        parent::tearDown();
+    }
+
+    /**
+     * test Authenticate
+     */
+    public function testAuthenticateFailure()
+    {
+        Time::setTestNow(Time::parse('2017-01-01 12:23:34'));
+
+        $request = (new ServerRequest([
+            'post' => [
+                'username' => 'foo',
+                'password' => 'invalid',
+            ],
+        ]))->withEnv('REMOTE_ADDR', '192.168.1.12');
+
+        $result = $this->auth->authenticate($request, $this->response);
+        $this->assertFalse($result);
+
+        // created attempt record on auth failure
+        $record = $this->Attempts->find()->where(['ip' => '192.168.1.12'])->first();
+        /* @var $record Attempt */
+        $this->assertNotEmpty($record, 'created attempt record on auth failure');
+
+        $this->assertSame('192.168.1.12', $record->ip);
+        $this->assertSame('AuthUsers.login', $record->action);
+        $this->assertSame('2017-01-01 12:28:34', $record->expires->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * test Authenticate
+     */
+    public function testAuthenticateLimitAttempts()
+    {
+        Time::setTestNow(Time::parse('2017-01-01 12:23:34'));
+
+        $request = (new ServerRequest([
+            'post' => [
+                'username' => 'foo',
+                'password' => 'password',
+            ],
+        ]))->withEnv('REMOTE_ADDR', '192.168.1.11');
+
+        $result = $this->auth->authenticate($request, $this->response);
+        $this->assertFalse($result);
+
+        // expired
+        Time::setTestNow(Time::parse('2017-01-02 12:23:35'));
+        $request = (new ServerRequest([
+            'post' => [
+                'username' => 'foo',
+                'password' => 'password',
+            ],
+        ]))->withEnv('REMOTE_ADDR', '192.168.1.11');
+
+        $result = $this->auth->authenticate($request, $this->response);
+        $this->assertSame(['id' => 1, 'username' => 'foo'], $result);
+    }
+
+    /**
+     * test Authenticate
+     */
+    public function testAuthenticateSuccess()
+    {
+        Time::setTestNow(Time::parse('2017-01-01 12:23:34'));
+
+        $result = $this->Attempts->find()->where(['ip' => '192.168.1.22'])->all();
+        $this->assertNotNull($result);
+        $this->assertCount(1, $result);
+        $request = new ServerRequest([
+            'post' => [
+                'username' => 'foo',
+                'password' => 'password',
+            ],
+        ]);
+        $request = $request->withEnv('REMOTE_ADDR', '192.168.1.22');
+
+        $result = $this->auth->authenticate($request, $this->response);
+        $this->assertNotEmpty($result);
+
+        // created attempt record on auth failure
+        $record = $this->Attempts->find()->where(['ip' => '192.168.1.2'])->all();
+        $this->assertCount(0, $record, 'reset attempt record on auth success');
+    }
+}


### PR DESCRIPTION
To prepare for the migration to CakePHP 4, we will make it available with the Authentication plugin.
